### PR TITLE
Solve issue #1, Accepting more arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ $ python3 mdcal.py 1970 1
 |26|27|28|29|30|31|1|
 ```
 
+
+
 ## Rendered Example
 
 2019/10

--- a/argvChecking.py
+++ b/argvChecking.py
@@ -1,0 +1,129 @@
+import mdcal
+
+USAGE = "Usage: python mdcal.py [year] [month]<Start with Sunday><Display week number><Only this month><language>"
+INVALID = "Invalid argument."
+
+"""
+Sanity check for the arguments
+"""
+# Helper methods
+def check_start_from_sun(argv):
+    if argv.lower() in ["true", "t", "1", "sun", "sunday", "s", "yes", "y"]:
+        mdcal.START_FROM_SUN = True
+        return True
+    elif argv.lower() in ["false",  "f", "0", "mon", "monday", "m", "no", "n"]:
+        mdcal.START_FROM_SUN = False
+        return True
+    else:
+        return False
+
+def check_true_false(argv):
+    if argv.lower() in ["true", "t", "1", "yes", "y"]:
+        return True
+    elif argv.lower() in ["false",  "f", "0", "no", "n"]:
+        return False
+    else:
+        return None
+    
+def check_language(argv):
+    if argv.lower() in ["en", "english", "eng", "e"]:
+        mdcal.LANG = mdcal.ENGLISH
+    elif argv.lower() in ["ja", "japanese", "jp", "j"]:
+        mdcal.LANG = mdcal.JAPANESE
+    elif argv.lower() in ["cht", "chinese", "cn", "c", "zh", "ch"]:
+        mdcal.LANG = mdcal.CHINESE
+    else:
+        return False
+    return True
+
+
+# ############################################# #
+# argv2 = y 
+def check_argv_2(argv):
+    if argv[1].isdigit():
+        year = int(argv[1])
+        if year < 2:
+            print(INVALID)
+        else: 
+            for month in range(1, 13):
+                mdcal.print_calendar(year, month)
+    else:
+        print(USAGE)
+
+# argv3 = y, m
+def check_argv_3(argv):
+    if argv[1].isdigit() and argv[2].isdigit():
+        year, month = [int(a) for a in argv[1:3]] 
+        if month < 1 or month > 12 or year < 2:
+            print(INVALID+USAGE)
+        else: 
+            mdcal.print_calendar(year, month)
+    else:
+        print(USAGE)
+
+
+# argv4 = y, m, sun
+def check_argv_4(argv):
+    if argv[1].isdigit() and argv[2].isdigit():
+        year, month = [int(a) for a in argv[1:3]] 
+        if month < 1 or month > 12 or year < 2:
+            print(INVALID+USAGE)
+        else: 
+            if check_start_from_sun(argv[3]):
+                mdcal.print_calendar(year, month)
+            else:
+                print(INVALID+USAGE)
+    else:
+        print(USAGE)
+
+
+
+# argv5 = y, m, sun, iso
+def check_argv_5(argv):
+    if argv[1].isdigit() and argv[2].isdigit():
+        year, month = [int(a) for a in argv[1:3]] 
+        if month < 1 or month > 12 or year < 2:
+            print(INVALID+USAGE)
+        else: 
+            if check_start_from_sun(argv[3]) and check_true_false(argv[4]) != None:
+                mdcal.WITH_ISOWEEK = check_true_false(argv[4])
+                mdcal.print_calendar(year, month)
+            else:
+                print(INVALID+USAGE)
+    else:
+        print(USAGE)
+
+
+
+# argv6 = y, m, sun, iso, only
+def check_argv_6(argv):
+    if argv[1].isdigit() and argv[2].isdigit():
+        year, month = [int(a) for a in argv[1:3]] 
+        if month < 1 or month > 12 or year < 2:
+            print(INVALID+USAGE)
+        else: 
+            if check_start_from_sun(argv[3]) and check_true_false(argv[4]) != None and check_true_false(argv[5]) != None:
+                mdcal.WITH_ISOWEEK = check_true_false(argv[4])
+                mdcal.ONLY_THIS_MONTH = check_true_false(argv[5])
+                mdcal.print_calendar(year, month)
+            else:
+                print(INVALID+USAGE)
+    else:
+        print(USAGE)
+
+
+# argv7 = y, m, sun, iso, only, lang
+def check_argv_7(argv):
+    if argv[1].isdigit() and argv[2].isdigit():
+        year, month = [int(a) for a in argv[1:3]] 
+        if month < 1 or month > 12 or year < 2:
+            print(INVALID+USAGE)
+        else: 
+            if check_start_from_sun(argv[3]) and check_true_false(argv[4]) != None and check_true_false(argv[5]) != None and check_language(argv[6]):
+                mdcal.WITH_ISOWEEK = check_true_false(argv[4])
+                mdcal.ONLY_THIS_MONTH = check_true_false(argv[5])
+                mdcal.print_calendar(year, month)
+            else:
+                print(INVALID+USAGE)
+    else:
+        print(USAGE)

--- a/mdcal.py
+++ b/mdcal.py
@@ -34,18 +34,25 @@ def create_calendar(year, month):
     mdstr += "|" + "|".join([":-:" for _ in range(len(colnames))]) + "|" + "\n"
 
     for days in cal.monthdatescalendar(year, month):
+        daystr = []
+        for day in days:
+            if ONLY_THIS_MONTH and day.month != month:
+                daystr.append(" ")
+            else:
+                daystr.append(str(day.day))
+
         if WITH_ISOWEEK:
             isoweek = days[0].isocalendar()[1]
             mdstr += (
                 "|"
                 + str(isoweek)
                 + "|"
-                + "|".join([str(d.day) for d in days])
+                + "|".join(daystr)
                 + "|"
                 + "\n"
             )
         else:
-            mdstr += "|" + "|".join([str(d.day) for d in days]) + "|" + "\n"
+            mdstr += "|" + "|".join(daystr) + "|" + "\n"
 
     return mdstr
 

--- a/mdcal.py
+++ b/mdcal.py
@@ -3,11 +3,12 @@
 import calendar
 from datetime import datetime
 import sys
+import argvChecking as ac
 
 ############################################################
-START_FROM_SUN = True  # If True, start the week from Sunday
+START_FROM_SUN = False  # If True, start the week from Sunday
 WITH_ISOWEEK = False  # If True, display the week number
-ONLY_THIS_MONTH = True  # If True, only display days within the month
+ONLY_THIS_MONTH = False  # If True, only display days within the month
 ENGLISH = "en"
 JAPANESE = "ja"
 CHINESE = "cht"
@@ -44,13 +45,7 @@ def create_calendar(year, month):
         if WITH_ISOWEEK:
             isoweek = days[0].isocalendar()[1]
             mdstr += (
-                "|"
-                + str(isoweek)
-                + "|"
-                + "|".join(daystr)
-                + "|"
-                + "\n"
-            )
+                "|" + str(isoweek) + "|" + "|".join(daystr) + "|" + "\n" )
         else:
             mdstr += "|" + "|".join(daystr) + "|" + "\n"
 
@@ -78,24 +73,23 @@ def get_dict():
         dic = {col: col for col in colnames}
     return dic
 
-
+# year, month, start day, iso week, only this month, lang
 if __name__ == "__main__":
     argv = sys.argv
-    if len(argv) == 1:
+    if len(argv) == 1: 
         today = datetime.now()
         print_calendar(today.year, today.month)
-    elif len(argv) == 2:
-        year = int(argv[1])
-        for month in range(1, 13):
-            print_calendar(year, month)
-    elif len(argv) == 3:
-        if argv[1].isdigit() and argv[2].isdigit():
-            year, month = [int(a) for a in argv[1:3]] 
-            if month < 1 or month > 12:
-                print("Invalid month. Please enter a valid month.")
-            else:
-                print_calendar(year, month)
-        else:
-            print("Usage: python mdcal.py [year] [month]")
+    elif len(argv) == 2:  ## y
+        ac.check_argv_2(argv)
+    elif len(argv) == 3: ## y, m
+        ac.check_argv_3(argv)
+    elif len(argv) == 4: ## y, m, sun
+        ac.check_argv_4(argv)
+    elif len(argv) == 5: ## y, m, sun, iso
+        ac.check_argv_5(argv)
+    elif len(argv) == 6: ## y, m, sun, iso, only
+        ac.check_argv_6(argv)
+    elif len(argv) == 7: ## y, m, sun, iso, only, lang
+        ac.check_argv_7(argv)
     else:
         print("Usage: python mdcal.py [year] [month]")

--- a/mdcal.py
+++ b/mdcal.py
@@ -1,56 +1,74 @@
 """Markdown Calendar Generator"""
+
 import calendar
 from datetime import datetime
 import sys
 
+############################################################
+START_FROM_SUN = True  # If True, start the week from Sunday
+WITH_ISOWEEK = False  # If True, display the week number
+ONLY_THIS_MONTH = True  # If True, only display days within the month
+ENGLISH = "en"
+JAPANESE = "ja"
+CHINESE = "cht"
+LANG = ENGLISH  # Language of the column names: en, ja, cht
+############################################################
 
-def create_calendar(year, month, with_isoweek=False, start_from_Sun=False, lang="en"):
-    firstweekday = 6 if start_from_Sun else 0
+
+def create_calendar(year, month):
+    firstweekday = 6 if START_FROM_SUN else 0
 
     cal = calendar.Calendar(firstweekday=firstweekday)
 
     mdstr = ""
-    dic = get_dict(lang)
+    dic = get_dict()
 
     colnames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-    if start_from_Sun:
+    if START_FROM_SUN:
         colnames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-    if with_isoweek:
+    if WITH_ISOWEEK:
         colnames.insert(0, "Week")
     colnames = [dic[col] for col in colnames]
 
-    mdstr += '|' + '|'.join(colnames) + '|' + '\n'
-    mdstr += '|' + '|'.join([':-:' for _ in range(len(colnames))]) + '|' + '\n'
+    mdstr += "|" + "|".join(colnames) + "|" + "\n"
+    mdstr += "|" + "|".join([":-:" for _ in range(len(colnames))]) + "|" + "\n"
 
     for days in cal.monthdatescalendar(year, month):
-        if with_isoweek:
+        if WITH_ISOWEEK:
             isoweek = days[0].isocalendar()[1]
-            mdstr += '|' + str(isoweek) + '|' + \
-                '|'.join([str(d.day) for d in days]) + '|' + '\n'
+            mdstr += (
+                "|"
+                + str(isoweek)
+                + "|"
+                + "|".join([str(d.day) for d in days])
+                + "|"
+                + "\n"
+            )
         else:
-            mdstr += '|' + '|'.join([str(d.day) for d in days]) + '|' + '\n'
+            mdstr += "|" + "|".join([str(d.day) for d in days]) + "|" + "\n"
 
     return mdstr
 
 
-def print_calendar(year, month, with_isoweek=False, start_from_Sun=False, lang="en"):
-    print('{}/{}\n'.format(year, month))
-    print(create_calendar(year, month, with_isoweek, start_from_Sun, lang))
+def print_calendar(year, month):
+    print("{}/{}\n".format(year, month))
+    print(create_calendar(year, month))
 
 
-def get_dict(lang='en'):
-    dic = {}
-    colnames = ['Week', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-    colnames_ja = ['週', '月', '火', '水', '木', '金', '土', '日']
-    if lang == 'en':
-        for col in colnames:
-            dic[col] = col
-    elif lang == 'ja':
-        for col, colja in zip(colnames, colnames_ja):
-            dic[col] = colja
+def get_dict():
+    colnames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    colnames_ja = ["月", "火", "水", "木", "金", "土", "日"]
+    colnames_cht = ["一", "二", "三", "四", "五", "六", "日"]
+    if WITH_ISOWEEK:
+        colnames.insert(0, "Week")
+        colnames_ja.insert(0, "週")
+        colnames_cht.insert(0, "週")
+    if LANG == "ja":
+        dic = dict(zip(colnames, colnames_ja))
+    elif LANG == "cht":
+        dic = dict(zip(colnames, colnames_cht))
     else:
-        for col in colnames:
-            dic[col] = col
+        dic = {col: col for col in colnames}
     return dic
 
 
@@ -62,9 +80,15 @@ if __name__ == "__main__":
     elif len(argv) == 2:
         year = int(argv[1])
         for month in range(1, 13):
-            print_calendar(year, month, with_isoweek=True)
+            print_calendar(year, month)
     elif len(argv) == 3:
-        year, month = [int(a) for a in argv[1:3]]
-        print_calendar(year, month)
+        if argv[1].isdigit() and argv[2].isdigit():
+            year, month = [int(a) for a in argv[1:3]] 
+            if month < 1 or month > 12:
+                print("Invalid month. Please enter a valid month.")
+            else:
+                print_calendar(year, month)
+        else:
+            print("Usage: python mdcal.py [year] [month]")
     else:
-        print('Usage: python mdcal.py [year] [month]')
+        print("Usage: python mdcal.py [year] [month]")


### PR DESCRIPTION
### Current Behavior
- terminal only accepts arguments for `year` and `month`.

### New Behavior
- Accepts more arguments in the order: `year`, `month`, `sun`, `iso`, `only`, `lang`.

#### Changes:
**Constants Added**: `START_FROM_SUN`, `WITH_ISOWEEK`, `ONLY_THIS_MONTH`, and `LANG` :
- `START_FROM_SUN` : True if the week starts on Sunday.
    - Accepted values: 
      - `["true", "t", "1", "sun", "sunday", "s", "yes", "y"]`
      - `["false", "f", "0", "mon", "monday", "m", "no", "n"]` 
- `WITH_ISOWEEK`: True to display week number
    - Accepted values: `["true", "t", "1", "yes", "y"]` and `["false", "f", "0", "no", "n"]` 
- `ONLY_THIS_MONTH`: Leaves days of other months as empty space without printing them.
    - Accepted values: `["true", "t", "1", "yes", "y"]` and `["false", "f", "0", "no", "n"]` 
- **`LANG`**
    - Accepted values: 
      - `["en", "english", "eng", "e"]` for English
      - `["ja", "japanese", "jp", "j"]` for Japanese
      -  `["cht", "chinese", "cn", "c", "zh", "ch"]` for Chinese.
      
![image](https://github.com/user-attachments/assets/f9fa4a0e-c3b3-4bba-9a4f-279fdc7c4887)
![image](https://github.com/user-attachments/assets/ef679f8a-1995-4a38-97ce-844acaf3896e)
